### PR TITLE
fix(diarizer): use K-Means centroids when speaker count constraint is applied

### DIFF
--- a/Sources/FluidAudio/Diarizer/Offline/Core/OfflineDiarizerManager.swift
+++ b/Sources/FluidAudio/Diarizer/Offline/Core/OfflineDiarizerManager.swift
@@ -448,6 +448,15 @@ public final class OfflineDiarizerManager {
             return ([], [:])
         }
 
+        // When K-Means was applied due to speaker count constraints,
+        // use the K-Means centroids directly instead of computing from gamma/pi
+        if vbxOutput.wasAdjusted, !vbxOutput.centroids.isEmpty {
+            let mapping = Dictionary(
+                uniqueKeysWithValues: (0..<vbxOutput.centroids.count).map { ($0, $0) }
+            )
+            return (vbxOutput.centroids, mapping)
+        }
+
         let epsilon = 1e-7
         let gamma = vbxOutput.gamma
         let pi = vbxOutput.pi


### PR DESCRIPTION
## Summary

Fixes #3 - `numSpeakers` constraint was not being applied to final diarization result.

**Root cause**: `computeCentroids()` always used `gamma/pi` from VBx output to compute centroids, ignoring the K-Means centroids stored in `vbxOutput.centroids` when `wasAdjusted=true`.

**Fix**: Check `wasAdjusted` flag first and use `vbxOutput.centroids` directly when K-Means was applied due to speaker count constraints.

## Changes

- `OfflineDiarizerManager.swift`: Added early return in `computeCentroids()` when `wasAdjusted=true`
- `SpeakerConstraintIntegrationTests.swift`: Added 5 integration tests for constraint enforcement

## Test plan

- [x] All 30 related tests pass (SpeakerConstraint, KMeans, VBxConstraint, OfflineConfig)
- [ ] Manual test with podcast audio (1 female intro + 2 male hosts) requesting `numSpeakers=2`